### PR TITLE
Fixes issue preventing propagation of Blur event when field value is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export default class NumberFormatInput extends Component {
         const handler = this._eventHandlers[key];
         this._eventHandlers[key] = e => {
           const result = handler(e);
-          if (result && this.props[key]) this.props[key](result);
+          this.props[key] && this.props[key](result);
         };
       });
     }
@@ -95,4 +95,3 @@ NumberFormatInput.propTypes = {
   onBlur: PropTypes.func,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
-


### PR DESCRIPTION
The local `onBlur` returns null when the input field has no value. Because `result` is then falsy, we never invoke the `onBlur` which is set on props. As long as there is a handler set on props, it should be called regardless of the input value.
